### PR TITLE
Upgrade to Linter v2

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -16,11 +16,15 @@ makeParameters = (globals, ignore, file) ->
   checkedAppend parameters, '--ignore', ignore
   parameters
 
-transformReport = (report, file) ->
-  report.type = if report.type == 'E' then 'Error' else 'Warning'
+reportToMessage = (report, file) ->
   ++report.range[1][1]
-  report.filePath = file
-  report
+
+  message =
+    location:
+      file: file
+      position: report.range
+    severity: if report.type == 'E' then 'error' else 'warning'
+    excerpt: report.text
 
 module.exports =
   config:
@@ -44,9 +48,10 @@ module.exports =
 
   provideLinter: ->
     provider =
+      name: 'Luacheck'
       grammarScopes: ['source.lua']
       scope: 'file'
-      lintOnFly: true
+      lintsOnChange: true
       lint: (editor) ->
         helpers ?= require('atom-linter')
         path ?= require('path')
@@ -64,4 +69,4 @@ module.exports =
           ignoreExitCode: true
         }).then (stdout) ->
           return helpers.parse(stdout, pattern).map (v)->
-            transformReport(v, file)
+            reportToMessage(v, file)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },
@@ -17,7 +17,7 @@
   "repository": "https://github.com/AtomLinter/linter-luacheck",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0"
+    "atom": ">=1.14.0 <2.0.0"
   },
   "dependencies": {
     "atom-linter": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "latest"
+    "atom-package-deps": "^4.5.0"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "devDependencies": {
     "coffeelint": "^1.15.7"

--- a/spec/linter-luacheck-spec.coffee
+++ b/spec/linter-luacheck-spec.coffee
@@ -32,27 +32,27 @@ describe 'The luacheck provider for Linter', ->
       return openFixtureFileInAtom('warning.lua').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 1
-          expect(messages[0].type).toBeDefined()
-          expect(messages[0].type).toEqual('Warning')
-          expect(messages[0].text).toBeDefined()
-          expect(messages[0].text).toEqual("unused argument 'self'")
-          expect(messages[0].filePath).toBeDefined()
-          expect(messages[0].filePath).toMatch(/.+warning\.lua$/)
-          expect(messages[0].range).toBeDefined()
-          expect(messages[0].range.length).toEqual(2)
-          expect(messages[0].range).toEqual([[2, 10], [2, 11]])
+          expect(messages[0].severity).toBeDefined()
+          expect(messages[0].severity).toEqual('warning')
+          expect(messages[0].excerpt).toBeDefined()
+          expect(messages[0].excerpt).toEqual("unused argument 'self'")
+          expect(messages[0].location.file).toBeDefined()
+          expect(messages[0].location.file).toMatch(/.+warning\.lua$/)
+          expect(messages[0].location.position).toBeDefined()
+          expect(messages[0].location.position.length).toEqual(2)
+          expect(messages[0].location.position).toEqual([[2, 10], [2, 11]])
 
   it 'finds error in error.lua', ->
     waitsForPromise ->
       return openFixtureFileInAtom('error.lua').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 1
-          expect(messages[0].type).toBeDefined()
-          expect(messages[0].type).toEqual('Error')
-          expect(messages[0].text).toBeDefined()
-          expect(messages[0].text).toEqual("expected identifier near 'local'")
-          expect(messages[0].filePath).toBeDefined()
-          expect(messages[0].filePath).toMatch(/.+error\.lua$/)
-          expect(messages[0].range).toBeDefined()
-          expect(messages[0].range.length).toEqual(2)
-          expect(messages[0].range).toEqual([[2, 6], [2, 11]])
+          expect(messages[0].severity).toBeDefined()
+          expect(messages[0].severity).toEqual('error')
+          expect(messages[0].excerpt).toBeDefined()
+          expect(messages[0].excerpt).toEqual("expected identifier near 'local'")
+          expect(messages[0].location.file).toBeDefined()
+          expect(messages[0].location.file).toMatch(/.+error\.lua$/)
+          expect(messages[0].location.position).toBeDefined()
+          expect(messages[0].location.position.length).toEqual(2)
+          expect(messages[0].location.position).toEqual([[2, 6], [2, 11]])

--- a/spec/linter-luacheck-spec.coffee
+++ b/spec/linter-luacheck-spec.coffee
@@ -45,12 +45,14 @@ describe 'The luacheck provider for Linter', ->
   it 'finds error in error.lua', ->
     waitsForPromise ->
       return openFixtureFileInAtom('error.lua').then (editor) ->
+        error_str = "expected identifier near 'local'"
+
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 1
           expect(messages[0].severity).toBeDefined()
           expect(messages[0].severity).toEqual('error')
           expect(messages[0].excerpt).toBeDefined()
-          expect(messages[0].excerpt).toEqual("expected identifier near 'local'")
+          expect(messages[0].excerpt).toEqual(error_str)
           expect(messages[0].location.file).toBeDefined()
           expect(messages[0].location.file).toMatch(/.+error\.lua$/)
           expect(messages[0].location.position).toBeDefined()


### PR DESCRIPTION
Upgrade to the Standard Linter v2 and Messages v2 protocols used by
Linter v2.

This fixes Issue #25 

I also made sure to update the specs to match the new Message protocol

NOTE: The minimal version of Atom is 1.14 since that is the minimal version required to install Linter v2.0.0